### PR TITLE
Fix node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "chalk-cli-spinner": "^0.2.0",
     "clean-css": "^3.0.7",
-    "cli-table": "^0.3.1",
+    "cli-table2": "^0.2.0",
     "commander": "^2.9.0",
     "es6-promise": "^2.0.0",
     "html-minifier": "^0.6.9",

--- a/src/listFiles.js
+++ b/src/listFiles.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Table = require('cli-table');
+var Table = require('cli-table2');
 
 
 module.exports = function(fields, colWidths){


### PR DESCRIPTION
Adding support for node 6, we had to upgrade serrialport and use a different cli-table package.
